### PR TITLE
php 8.4 explicit nullable type fix

### DIFF
--- a/DataCollector/MCPDataCollector.php
+++ b/DataCollector/MCPDataCollector.php
@@ -24,7 +24,7 @@ class MCPDataCollector extends DataCollector implements LateDataCollectorInterfa
     /**
      * {@inheritdoc}
      */
-    public function collect(Request $request, Response $response, \Throwable $exception = null): void
+    public function collect(Request $request, Response $response, ?\Throwable $exception = null): void
     {
         $this->data = [
             'name' => $this->name,


### PR DESCRIPTION
add explicit nullable type, emits a deprecation warning on php 8.4

```
Killerwolf\MCPProfilerBundle\DataCollector\MCPDataCollector::collect(): Implicitly marking parameter $exception as nullable is deprecated, the explicit nullable type must be used instead
```